### PR TITLE
新增前端正式環境 NEXT_PUBLIC_API_BASE_URL

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/eventa-frontend
+  NEXT_PUBLIC_API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_BASE_URL }}
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Story/Why
Linked Trello: https://trello.com/c/I78fEi46
發現因為 npm run build 是在 GitHub Actions 執行，需要在 cd.yml 內加入 專案中設定的 NEXT_PUBLIC_API_BASE_URL 才能吃到正式環境變數

## Solution
- 在此 Repo Settings 加入環境變數設定
- cd.yml 新增 NEXT_PUBLIC_API_BASE_URL 設定