### PR TITLE
[個人檔案] 修正 React hydration mismatch 錯誤 / date picker 開啟未正確在設定的日期

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,5 +1,11 @@
 "use client";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   NavigationMenu,
   NavigationMenuItem,
@@ -127,6 +133,9 @@ export default function Navbar() {
         <DialogContent className="max-w-md w-full">
           <DialogHeader>
             <DialogTitle>{loginTab === "signin" ? "登入" : "註冊"}</DialogTitle>
+            <DialogDescription>
+              {loginTab === "signin" ? "請輸入您的帳號密碼進行登入" : "請填寫資料完成註冊"}
+            </DialogDescription>
           </DialogHeader>
           <div className="py-2">
             {loginTab === "signin" ? (

--- a/src/features/profile/components/ProfileForm.tsx
+++ b/src/features/profile/components/ProfileForm.tsx
@@ -365,7 +365,9 @@ export default function ProfileForm({ initialData }: ProfileFormProps) {
                       startMonth={new Date(1900, 0)}
                       endMonth={new Date(new Date().getFullYear(), 11)}
                       defaultMonth={
-                        new Date(defaultBirthDate.getFullYear(), defaultBirthDate.getMonth())
+                        field.value
+                          ? new Date(field.value.getFullYear(), field.value.getMonth())
+                          : new Date(defaultBirthDate.getFullYear(), defaultBirthDate.getMonth())
                       }
                       disabledDates={isDateDisabled}
                       components={{ Dropdown: CustomSelectDropdown }}


### PR DESCRIPTION
## Story/Why

Linked Trello: [https://trello.com/c/oPbCIEjY](https://trello.com/c/oPbCIEjY )
修正使用者開啟 Dialog 元件時出現的可存取性警告（缺少 DialogDescription）與生日 Date Picker 未正確顯示年月的問題。
Warning: Missing Description or aria-describedby={undefined} for
{DialogContent}.

## Solution

- 登入 dialog 補上 `<DialogDescription>`
- ProfileForm 修改 defaultMonth 設定


## Additional Note

教練提到錯誤訊息
![image](https://github.com/user-attachments/assets/be77bd9f-6b85-4259-b0c1-5b9bbafee913)
目前測試沒看到，應該是先前更新重構版本後就處理掉了
測試時再確認看看是否有此錯誤