### PR TITLE
[個人檔案] 修正 React hydration mismatch 錯誤

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-TW">
-      <body className={`${notoSansTC.variable} antialiased`}>
+      <body
+        className={`${notoSansTC.variable} antialiased`}
+        suppressHydrationWarning
+      >
         <Navbar />
         {children}
         <Toaster />


### PR DESCRIPTION
## Story/Why
Linked Trello: https://trello.com/c/oPbCIEjY
處理 React hydration mismatch 錯誤
![image](https://github.com/user-attachments/assets/bc351338-81dc-45ff-83af-3acc7becebc9)


## Solution
參考文件解決方式
https://react.dev/reference/react-dom/client/hydrateRoot#suppressing-unavoidable-hydration-mismatch-errors
https://nextjs.org/docs/messages/react-hydration-error#solution-3-using-suppresshydrationwarning
Solution 3: Using suppressHydrationWarning
Sometimes content will inevitably differ between the server and client, such as a timestamp. You can silence the hydration mismatch warning by adding suppressHydrationWarning={true} to the element.
有時候內容在伺服器和客戶端之間不可避免地會有所不同，例如時間戳記。您可以透過在元素中加入 suppressHydrationWarning={true} 來消除水合不匹配的警告。
