### PR TITLE
fix: 流程測試 bug 修正以功能優化

### DIFF
--- a/src/app/(create-event)/create-event/[eventId]/basicinfo/page.tsx
+++ b/src/app/(create-event)/create-event/[eventId]/basicinfo/page.tsx
@@ -263,7 +263,7 @@ export default function BasicInfoPage() {
   }
 
   return (
-    <div className="p-6">
+    <div>
       <h1 className="text-2xl font-bold mb-6">建立活動資訊頁面！</h1>
 
       {/* 封面圖片上傳區域 */}

--- a/src/app/(create-event)/create-event/[eventId]/intro/page.tsx
+++ b/src/app/(create-event)/create-event/[eventId]/intro/page.tsx
@@ -161,7 +161,7 @@ export default function IntroPage() {
   }
 
   return (
-    <div className="p-6">
+    <div>
       <h1 className="text-2xl font-bold mb-6">
         詳細介紹你的活動內容，讓參加者了解活動且提高參加意願！
       </h1>

--- a/src/app/(create-event)/create-event/[eventId]/tickets/setting/page.tsx
+++ b/src/app/(create-event)/create-event/[eventId]/tickets/setting/page.tsx
@@ -868,7 +868,9 @@ export default function TicketSettingPage() {
               throw new Error(ticketResponse.error.message || "更新票券失敗，請稍後再試");
             }
           }
-        } // 4. 發布活動
+        }
+
+        // 4. 發布活動
         const publishResponse = await patchApiV1ActivitiesByActivityIdPublish({
           path: { activityId: numericEventId },
         });

--- a/src/app/(create-event)/create-event/organizer/page.tsx
+++ b/src/app/(create-event)/create-event/organizer/page.tsx
@@ -4,6 +4,7 @@ import CreateOrganizerDialog from "@/features/organizer/components/create-organi
 import { getApiV1Organizations } from "@/services/api/client/sdk.gen";
 import type { OrganizationResponse } from "@/services/api/client/types.gen";
 import { useCreateEventStore } from "@/store/create-event";
+import { useOrganizerStore } from "@/store/organizer";
 import { useErrorHandler } from "@/utils/error-handler";
 import { cn } from "@/utils/transformer";
 import { Building } from "lucide-react";
@@ -20,8 +21,13 @@ export default function CreateEventOrganizerPage() {
   // 錯誤處理
   const { handleError } = useErrorHandler();
 
-  const { organizationInfo, hasUnfinishedEvent, setOrganizationInfo, clearAllData } =
-    useCreateEventStore();
+  const organizationInfo = useCreateEventStore((state) => state.organizationInfo);
+  const hasUnfinishedEvent = useCreateEventStore((state) => state.hasUnfinishedEvent);
+  const setOrganizationInfo = useCreateEventStore((state) => state.setOrganizationInfo);
+  const clearAllData = useCreateEventStore((state) => state.clearAllData);
+
+  const setCurrentOrganizerId = useOrganizerStore((state) => state.setCurrentOrganizerId);
+  const fetchCurrentOrganizerInfo = useOrganizerStore((state) => state.fetchCurrentOrganizerInfo);
 
   // 載入主辦單位列表
   const loadOrganizations = useCallback(async () => {
@@ -64,13 +70,16 @@ export default function CreateEventOrganizerPage() {
   };
 
   // 處理選擇按鈕點擊 - 只儲存主辦單位資訊，不建立活動
-  const handleSelect = () => {
+  const handleSelect = async () => {
     if (selected && selectedOrgName) {
       // 儲存主辦單位資訊到 store
       setOrganizationInfo({
         organizationId: selected,
         organizationName: selectedOrgName,
       });
+
+      setCurrentOrganizerId(selected);
+      await fetchCurrentOrganizerInfo();
 
       // 導航到活動形式選擇頁面
       router.push("/create-event/new/eventplacetype");

--- a/src/app/(organizer)/create/page.tsx
+++ b/src/app/(organizer)/create/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Camera, Image, Plus, RefreshCw, Upload, X } from "lucide-react";
+import { Camera, Image, RefreshCw, Upload, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
@@ -12,16 +12,15 @@ import {
   postApiV1Organizations,
   postApiV1OrganizationsByOrganizationIdImages,
 } from "@/services/api/client/sdk.gen";
-import { useDialogStore } from "@/store/dialog";
 import { useOrganizerStore } from "@/store/organizer";
 import { useErrorHandler } from "@/utils/error-handler";
 import { cn } from "@/utils/transformer";
 
 export default function CreateOrganizerPage() {
   const router = useRouter();
-  const { showError } = useDialogStore();
   const { handleError } = useErrorHandler();
-  const { setCurrentOrganizer } = useOrganizerStore();
+  const setCurrentOrganizerId = useOrganizerStore((state) => state.setCurrentOrganizerId);
+  const fetchCurrentOrganizerInfo = useOrganizerStore((state) => state.fetchCurrentOrganizerInfo);
 
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [coverImagePreview, setCoverImagePreview] = useState<string | null>(null);
@@ -133,7 +132,8 @@ export default function CreateOrganizerPage() {
         }
 
         // 設定為當前主辦單位
-        setCurrentOrganizer(organizationId, data.organizerName);
+        setCurrentOrganizerId(organizationId);
+        await fetchCurrentOrganizerInfo();
 
         // 導航回主辦者中心
         router.push("/organizer");

--- a/src/app/(organizer)/organizer/events/[eventId]/attendees/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/attendees/page.tsx
@@ -241,7 +241,7 @@ export default function AttendeesPage() {
                             : "-"}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          {participant.status === "unassigned" && (
+                          {participant.status === "assigned" && (
                             <Button
                               size="sm"
                               onClick={() =>
@@ -255,18 +255,6 @@ export default function AttendeesPage() {
                               <CheckCircle className="w-4 h-4 mr-1" />
                               報到
                             </Button>
-                          )}
-                          {participant.status === "used" && (
-                            <span className="text-emerald-600 font-medium">已使用</span>
-                          )}
-                          {participant.status === "assigned" && (
-                            <span className="text-blue-600 font-medium">已分配</span>
-                          )}
-                          {participant.status === "canceled" && (
-                            <span className="text-rose-600 font-medium">已取消</span>
-                          )}
-                          {participant.status === "overdue" && (
-                            <span className="text-gray-600 font-medium">已逾期</span>
                           )}
                         </td>
                       </tr>
@@ -353,7 +341,7 @@ export default function AttendeesPage() {
                           </span>
                         </div>
                       </div>
-                      {participant.status === "unassigned" && (
+                      {participant.status === "assigned" && (
                         <div className="mt-3">
                           <Button
                             size="sm"

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/basicinfo/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/basicinfo/page.tsx
@@ -35,8 +35,7 @@ export default function BasicInfoPage() {
   const { showError } = useDialogStore();
 
   // 從 organizer store 獲取主辦單位資訊
-  const { getCurrentOrganizerInfo } = useOrganizerStore();
-  const currentOrganizerInfo = getCurrentOrganizerInfo();
+  const currentOrganizerInfo = useOrganizerStore((s) => s.currentOrganizerInfo);
 
   // 本地狀態
   const [isUpdating, setIsUpdating] = useState(false);

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/tickets/setting/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/tickets/setting/page.tsx
@@ -808,10 +808,14 @@ export default function TicketSettingPage() {
             isActive: true,
           }));
 
-          await postApiV1ActivitiesByActivityIdTicketTypes({
+          const addTickResponse = await postApiV1ActivitiesByActivityIdTicketTypes({
             path: { activityId: numericEventId },
             body: ticketData,
           });
+
+          if (addTickResponse.error) {
+            throw new Error(addTickResponse.error.message || "新增票券失敗，請稍後再試");
+          }
         }
 
         // 3. 處理更新現有票券
@@ -822,35 +826,38 @@ export default function TicketSettingPage() {
         for (const ticket of existingTickets) {
           const ticketId = Number.parseInt(ticket.id);
           if (!Number.isNaN(ticketId)) {
-            const ticketResponse = await putApiV1ActivitiesByActivityIdTicketTypesByTicketTypeId({
-              path: {
-                activityId: numericEventId,
-                ticketTypeId: ticketId,
-              },
-              body: {
-                name: ticket.name,
-                price: ticket.price,
-                totalQuantity: ticket.quantity,
-                remainingQuantity: ticket.quantity,
-                startTime: combineDateTime(
-                  ticket.saleStartDate,
-                  ticket.saleStartHour,
-                  ticket.saleStartMinute
-                ),
-                endTime: combineDateTime(
-                  ticket.saleEndDate,
-                  ticket.saleEndHour,
-                  ticket.saleEndMinute
-                ),
-                isActive: true,
-              },
-            });
+            const updateTicketResponse =
+              await putApiV1ActivitiesByActivityIdTicketTypesByTicketTypeId({
+                path: {
+                  activityId: numericEventId,
+                  ticketTypeId: ticketId,
+                },
+                body: {
+                  name: ticket.name,
+                  price: ticket.price,
+                  totalQuantity: ticket.quantity,
+                  remainingQuantity: ticket.quantity,
+                  startTime: combineDateTime(
+                    ticket.saleStartDate,
+                    ticket.saleStartHour,
+                    ticket.saleStartMinute
+                  ),
+                  endTime: combineDateTime(
+                    ticket.saleEndDate,
+                    ticket.saleEndHour,
+                    ticket.saleEndMinute
+                  ),
+                  isActive: true,
+                },
+              });
 
-            if (ticketResponse.error) {
-              throw new Error(ticketResponse.error.message || "更新票券失敗，請稍後再試");
+            if (updateTicketResponse.error) {
+              throw new Error(updateTicketResponse.error.message || "更新票券失敗，請稍後再試");
             }
           }
         }
+
+        await loadTickets();
 
         toast.success("活動票券設定已成功更新");
       } catch (error) {

--- a/src/app/(organizer)/organizer/events/[eventId]/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/page.tsx
@@ -294,7 +294,7 @@ export default function EventDetailPage() {
   if (isLoading) {
     return (
       <div className="flex flex-col h-full items-center justify-center">
-        <div className="text-lg text-gray-600">載入總攬資料中...</div>
+        <div className="text-lg text-gray-600">載入總覽資料中...</div>
       </div>
     );
   }

--- a/src/app/(organizer)/organizer/events/page.tsx
+++ b/src/app/(organizer)/organizer/events/page.tsx
@@ -522,7 +522,7 @@ export default function EventsPage() {
     else if (currentStatus === ActivityStatus.CANCELED) counts.canceled = currentStatusTotal;
 
     return counts;
-  }, [pagination.totalItems]);
+  }, [pagination.totalItems, activeFilters.status]);
 
   // 清除篩選
   const handleClearFilters = () => {
@@ -632,6 +632,7 @@ export default function EventsPage() {
           value={activeFilters.status}
           onValueChange={handleStatusFilterChange}
           counts={eventCounts}
+          loading={loading}
         />
 
         {/* 活動列表 */}

--- a/src/app/(organizer)/organizer/layout.tsx
+++ b/src/app/(organizer)/organizer/layout.tsx
@@ -88,10 +88,7 @@ export default async function OrganizerLayout({
         suppressHydrationWarning
       >
         <Suspense fallback={<div>Loading...</div>}>
-          <InitOrganizerState
-            orgId={defaultOrg.id || -1}
-            orgName={defaultOrg.name || ""}
-          >
+          <InitOrganizerState orgId={defaultOrg.id || -1}>
             <OrganizerLayoutContent>{children}</OrganizerLayoutContent>
           </InitOrganizerState>
         </Suspense>

--- a/src/app/(organizer)/organizer/page.tsx
+++ b/src/app/(organizer)/organizer/page.tsx
@@ -53,40 +53,37 @@ export default function OrganizerHomePage() {
     },
   });
 
-  const fetchOrganizerDetail = useCallback(async () => {
-    const currentOrganizer = await fetchCurrentOrganizerInfo();
-    if (!currentOrganizer) {
-      setIsLoading(false);
+  const updateOrganizerInfo = useCallback(async () => {
+    if (!currentOrganizerInfo) {
+      setIsLoading(true);
       return;
     }
 
-    setOrganizerInfo(currentOrganizer);
+    setOrganizerInfo(currentOrganizerInfo);
     reset({
-      organizerName: currentOrganizer.name || "",
-      description: currentOrganizer.introduction || "",
-      phoneNumber: currentOrganizer.phoneNumber || "",
-      email: currentOrganizer.email || "",
+      organizerName: currentOrganizerInfo.name || "",
+      description: currentOrganizerInfo.introduction || "",
+      phoneNumber: currentOrganizerInfo.phoneNumber || "",
+      email: currentOrganizerInfo.email || "",
       language: "繁體中文",
-      currency: currentOrganizer.currency || "TWD",
-      countryCode: `台灣 ${currentOrganizer.countryCode || "+886"}`,
+      currency: currentOrganizerInfo.currency || "TWD",
+      countryCode: `台灣 ${currentOrganizerInfo.countryCode || "+886"}`,
     });
 
-    setAvatarPreview(currentOrganizer?.avatar || null);
-    setCoverImagePreview(currentOrganizer?.cover || null);
+    setAvatarPreview(currentOrganizerInfo?.avatar || null);
+    setCoverImagePreview(currentOrganizerInfo?.cover || null);
     setIsLoading(false);
-  }, [fetchCurrentOrganizerInfo, reset]);
+  }, [currentOrganizerInfo]);
 
   // 監聽 currentOrganizerInfo 的變更
   useEffect(() => {
-    if (currentOrganizerInfo?.id) {
-      fetchOrganizerDetail();
-    }
-  }, [currentOrganizerInfo?.id, fetchOrganizerDetail]);
+    updateOrganizerInfo();
+  }, [currentOrganizerInfo]);
 
   // 初始載入
   useEffect(() => {
-    fetchOrganizerDetail();
-  }, [fetchOrganizerDetail]);
+    updateOrganizerInfo();
+  }, []);
 
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] || null;
@@ -218,8 +215,8 @@ export default function OrganizerHomePage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500" />
+      <div className="flex flex-col h-full items-center justify-center">
+        <div className="text-lg text-gray-600">載入主辦中心資料中...</div>
       </div>
     );
   }

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -19,6 +19,7 @@ import SignUpForm from "@/features/auth/components/sign-up-form";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useAuthStore } from "@/store/auth";
 import { useDialogStore } from "@/store/dialog";
+import { useOrganizerStore } from "@/store/organizer";
 import { ChevronLeft, Menu, SquarePen, Ticket, User, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -33,6 +34,7 @@ export default function Header() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const logout = useAuthStore((s) => s.logout);
   const userProfile = useAuthStore((s) => s.userProfile);
+  const clearCurrentOrganizer = useOrganizerStore((s) => s.clearCurrentOrganizer);
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -282,6 +284,7 @@ export default function Header() {
                           className="flex items-center w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-gray-50"
                           onClick={() => {
                             logout();
+                            clearCurrentOrganizer();
                             router.push("/");
                           }}
                         >
@@ -459,6 +462,7 @@ export default function Header() {
                     className="border border-neutral-400 rounded-lg px-4 py-3 text-xs text-neutral-600 cursor-pointer"
                     onClick={() => {
                       logout();
+                      clearCurrentOrganizer();
                       setMobileMenuOpen(false);
                       setMobileUserMenuOpen(false);
                       router.push("/");

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -14,12 +14,13 @@ export const Navbar = () => {
   const menuRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const logout = useAuthStore((s) => s.logout);
+  const clearCurrentOrganizer = useOrganizerStore((s) => s.clearCurrentOrganizer);
   const currentOrganizerInfo = useOrganizerStore((s) => s.currentOrganizerInfo);
 
   // 處理選擇主辦單位成功
   const handleOrganizerSelected = () => {
     setMenuOpen(false);
-    // 可以在這裡添加其他邏輯，比如刷新頁面或顯示成功訊息
+    router.push("/organizer");
   };
 
   return (
@@ -111,6 +112,7 @@ export const Navbar = () => {
                       className="flex items-center w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-gray-50 cursor-pointer"
                       onClick={() => {
                         logout();
+                        clearCurrentOrganizer();
                         router.push("/");
                       }}
                     >

--- a/src/components/layout/sidebar-nav.tsx
+++ b/src/components/layout/sidebar-nav.tsx
@@ -336,6 +336,7 @@ export const SidebarNav = () => {
               className="flex items-center text-left px-4 py-3 text-sm text-neutral-600 border border-neutral-600 rounded-md hover:bg-gray-50 cursor-pointer"
               onClick={() => {
                 logout();
+                clearCurrentOrganizer();
                 router.push("/");
               }}
             >

--- a/src/components/ui/activity-tabs.tsx
+++ b/src/components/ui/activity-tabs.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils/transformer";
-import { CheckCircle, FileText, Globe, XCircle } from "lucide-react";
+import { CheckCircle, FileText, Globe, Loader, XCircle } from "lucide-react";
 import type React from "react";
 
 export type ActivityTabsValue = "draft" | "published" | "ended" | "canceled";
@@ -13,6 +13,7 @@ export interface ActivityTabsProps {
     ended: number;
     canceled: number;
   };
+  loading?: boolean;
   className?: string;
 }
 
@@ -55,6 +56,7 @@ export const ActivityTabs: React.FC<ActivityTabsProps> = ({
   value,
   onValueChange,
   counts,
+  loading,
   className,
 }) => {
   return (
@@ -79,11 +81,15 @@ export const ActivityTabs: React.FC<ActivityTabsProps> = ({
                 <span className="mr-1 md:mr-2 truncate">{tab.label}</span>
                 <span
                   className={cn(
-                    "inline-flex items-center justify-center px-1 sm:px-1.5 md:px-2 py-0.5 md:py-1 text-xs font-medium rounded-full min-w-[16px] sm:min-w-[18px] md:min-w-[20px] flex-shrink-0",
+                    "inline-flex items-center justify-center h-5 md:h-[26px] text-xs font-medium rounded-full min-w-[16px] sm:min-w-[18px] md:min-w-[22px] flex-shrink-0",
                     isActive ? tab.countClass : "bg-gray-100 hidden"
                   )}
                 >
-                  {counts[tab.value]}
+                  {loading ? (
+                    <Loader className={cn("animate-spin h-3 w-3 text-gray-500", tab.countClass)} />
+                  ) : (
+                    counts[tab.value]
+                  )}
                 </span>
               </button>
             );

--- a/src/components/ui/tags-input.tsx
+++ b/src/components/ui/tags-input.tsx
@@ -99,6 +99,10 @@ const TagsInput = forwardRef<HTMLDivElement, TagsInputProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+
       if (e.key === "Enter" || e.key === ",") {
         e.preventDefault();
         addMultipleTags();

--- a/src/features/organizer/components/InitOrganizerState.tsx
+++ b/src/features/organizer/components/InitOrganizerState.tsx
@@ -1,23 +1,39 @@
 "use client";
 
 import { useOrganizerStore } from "@/store/organizer";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 interface InitOrganizerStateProps {
   orgId: number;
-  orgName: string;
   children: React.ReactNode;
 }
 
-export function InitOrganizerState({ orgId, orgName, children }: InitOrganizerStateProps) {
-  const currentOrganizerInfo = useOrganizerStore((state) => state.currentOrganizerInfo);
-  const setCurrentOrganizer = useOrganizerStore((state) => state.setCurrentOrganizer);
+export function InitOrganizerState({ orgId, children }: InitOrganizerStateProps) {
+  const [isInitialized, setIsInitialized] = useState(false);
+  const setCurrentOrganizerId = useOrganizerStore((s) => s.setCurrentOrganizerId);
+  const fetchCurrentOrganizerInfo = useOrganizerStore((s) => s.fetchCurrentOrganizerInfo);
 
   useEffect(() => {
-    if (!currentOrganizerInfo) {
-      setCurrentOrganizer(orgId, orgName);
+    if (isInitialized) return;
+
+    const initializeOrganizer = (state: any) => {
+      if (!state.currentId) {
+        console.log("設置新的 organizer ID:", orgId);
+        setCurrentOrganizerId(orgId);
+        fetchCurrentOrganizerInfo();
+      }
+      setIsInitialized(true);
+    };
+
+    // 如果已經 hydrated，立即執行
+    if (useOrganizerStore.persist.hasHydrated()) {
+      initializeOrganizer(useOrganizerStore.getState());
+      return;
     }
-  }, [currentOrganizerInfo, orgId, orgName, setCurrentOrganizer]);
+
+    const unsubscribe = useOrganizerStore.persist.onFinishHydration(initializeOrganizer);
+    return unsubscribe;
+  }, []);
 
   return <>{children}</>;
 }

--- a/src/features/organizer/components/create-organizer-dialog.tsx
+++ b/src/features/organizer/components/create-organizer-dialog.tsx
@@ -30,7 +30,7 @@ interface CreateOrganizerDialogProps {
 
 export function CreateOrganizerDialog({ onSuccess, children }: CreateOrganizerDialogProps) {
   const { handleError } = useErrorHandler();
-  const { setCurrentOrganizer } = useOrganizerStore();
+  const { setCurrentOrganizerId, fetchCurrentOrganizerInfo } = useOrganizerStore();
 
   const [open, setOpen] = useState(false);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
@@ -143,7 +143,8 @@ export function CreateOrganizerDialog({ onSuccess, children }: CreateOrganizerDi
         }
 
         // 設定為當前主辦單位
-        setCurrentOrganizer(organizationId, data.organizerName);
+        setCurrentOrganizerId(organizationId);
+        await fetchCurrentOrganizerInfo();
 
         onSuccess?.();
 

--- a/src/services/api/interceptors.ts
+++ b/src/services/api/interceptors.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from "@/store/auth";
+import { useOrganizerStore } from "@/store/organizer";
 import { toast } from "sonner";
 import { client } from "./client/client.gen";
 
@@ -13,6 +14,7 @@ client.interceptors.response.use(async (response) => {
       toast.error("認證已過期，請重新登入");
       // 清除當前的認證狀態
       await useAuthStore.getState().logout();
+      await useOrganizerStore.getState().clearCurrentOrganizer();
       // 重定向到登入頁面
       window.location.href = "/?authRequired=1";
     }

--- a/src/store/organizer.ts
+++ b/src/store/organizer.ts
@@ -4,44 +4,39 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface OrganizerState {
+  // 當前主辦單位的 ID
+  currentId: number | null;
   // 當前主辦單位的基本資訊
   currentOrganizerInfo: OrganizationResponse | null;
 
   // Actions
-  setCurrentOrganizer: (id: number, name: string) => void;
+  setCurrentOrganizerId: (id: number) => void;
   clearCurrentOrganizer: () => void;
-  getCurrentOrganizerId: () => number | null;
-  getCurrentOrganizerInfo: () => OrganizationResponse | null;
   fetchCurrentOrganizerInfo: () => Promise<OrganizationResponse | null>;
 }
 
 export const useOrganizerStore = create<OrganizerState>()(
   persist(
     (set, get) => ({
+      currentId: null,
+
       currentOrganizerInfo: null,
 
-      setCurrentOrganizer: (id: number, name: string) => {
+      setCurrentOrganizerId: (id: number) => {
         set({
-          currentOrganizerInfo: { id, name },
+          currentId: id,
         });
       },
 
       clearCurrentOrganizer: () => {
         set({
+          currentId: null,
           currentOrganizerInfo: null,
         });
       },
 
-      getCurrentOrganizerId: () => {
-        return get().currentOrganizerInfo?.id ?? null;
-      },
-
-      getCurrentOrganizerInfo: () => {
-        return get().currentOrganizerInfo;
-      },
-
       fetchCurrentOrganizerInfo: async () => {
-        const currentId = get().getCurrentOrganizerId();
+        const currentId = get().currentId;
         if (!currentId) return null;
 
         try {
@@ -67,6 +62,7 @@ export const useOrganizerStore = create<OrganizerState>()(
     {
       name: "organizer-store", // localStorage key
       partialize: (state) => ({
+        currentId: state.currentId,
         currentOrganizerInfo: state.currentOrganizerInfo,
       }),
     }


### PR DESCRIPTION
## Story/Why
Linked Trello: (對應 Trello 卡片之連結)
X

## Solution
修正流程測試錯誤並優化功能
* [創建兩個主辦單位，並在第二個主辦創建活動，如果要編輯這一個活動，點擊查看，上面大頭照的位置的主辦單位會變成順位一的主辦單位](https://www.notion.so/2166a2468518804eae77ed58de892aae?source=copy_link)
* [編輯活動 票券設定 新建立的活動票券 更新錯誤訊息未顯示](https://www.notion.so/2166a246851880c6b55ad2f5d3126d89?source=copy_link)
* [重新登入沒有清除先前選擇的主辦單位](https://www.notion.so/2156a246851880358c1df5e938e1f911?source=copy_link)
* [活動建立 上下步 按鈕缺少間距](https://www.notion.so/2156a24685188037a9d4ed798aae64f5?source=copy_link)
* [活動總攬 返回 活動列表 主辦單位被切喚回獲取的第一個主辦](https://www.notion.so/2166a246851880f5926ed2008b7c919a?source=copy_link)
* [參與者名單 重複的顯示票券狀態](https://www.notion.so/2166a2468518803fabfde3bfcec325fb?source=copy_link)
* [活動建立 標籤加入後未清除](https://www.notion.so/2166a246851880c7862bce56fce4f600?source=copy_link)
* [發佈活動後回主辦中心 主辦單位未正確切換](https://www.notion.so/2166a246851880588509e96e4abbbf07?source=copy_link)
* [主辦中心 草稿活動未顯示正確數量](https://www.notion.so/2166a2468518806d80abc3781b485126?source=copy_link)
* [主辦中心載入資料畫面錯字](https://www.notion.so/2176a2468518807da4d7d4b6ca913b69?source=copy_link)
* [活動報到：目前免費票及付款成功的付費票看起來都會是 已分配（assigned），畫面上不會顯示報到按鈕](https://www.notion.so/assigned-2176a246851880b89c67ffe7fa3719f8?source=copy_link)
* [活動管理：草稿，有草稿，但是未顯示數量](https://www.notion.so/2166a246851880adab18f2d7d8ab1b75?source=copy_link)

## Additional Note
X
