### PR TITLE
fix: 編輯活動卡控調整、錯誤訊息顯示修正、footer 假路徑調整

### DIFF
--- a/src/app/(create-event)/create-event/[eventId]/eventplacetype/page.tsx
+++ b/src/app/(create-event)/create-event/[eventId]/eventplacetype/page.tsx
@@ -129,9 +129,15 @@ export default function EventPlaceTypePage() {
         }
       }
     } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : eventId === "new"
+            ? "建立活動失敗，請稍後再試"
+            : "更新活動失敗，請稍後再試";
+
       handleError(error, {
-        customErrorMessage:
-          eventId === "new" ? "建立活動失敗，請稍後再試" : "更新活動失敗，請稍後再試",
+        customErrorMessage: errorMessage,
       });
     } finally {
       setIsCreating(false);

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/basicinfo/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/basicinfo/page.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type React from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { toast } from "sonner";
+import { ActivityStatus } from "../../../page";
 
 // 固定選項
 const TIMEZONE_OPTIONS = [{ value: "(GMT+08:00) 台北", label: "(GMT+08:00) 台北" }];
@@ -171,6 +172,14 @@ export default function BasicInfoPage() {
   const onSubmit = useCallback(
     async (data: BasicInfoFormData) => {
       const numericEventId = Number.parseInt(eventId);
+      if (
+        activityData?.status === ActivityStatus.ENDED ||
+        activityData?.status === ActivityStatus.CANCELED
+      ) {
+        showError("無法編輯已結束或已取消的活動");
+        return;
+      }
+
       if (Number.isNaN(numericEventId)) {
         showError("無效的活動 ID");
         return;
@@ -488,7 +497,12 @@ export default function BasicInfoPage() {
         <div className="flex justify-center border-t border-gray-200 pt-6">
           <Button
             type="submit"
-            disabled={!isValid || isUpdating}
+            disabled={
+              !isValid ||
+              isUpdating ||
+              activityData?.status === ActivityStatus.ENDED ||
+              activityData?.status === ActivityStatus.CANCELED
+            }
             className={`${
               isValid && !isUpdating
                 ? "bg-[#FFD56B] hover:bg-[#FFCA28] cursor-pointer"

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/category/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/category/page.tsx
@@ -12,6 +12,7 @@ import { Info } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { ActivityStatus } from "../../../page";
 
 // 主題圖標組件
 const CategoryIcon = ({
@@ -123,6 +124,14 @@ export default function CategoryPage() {
   const handleSubmit = async () => {
     if (selectedCategories.length === 0) return;
 
+    if (
+      activityData?.status === ActivityStatus.ENDED ||
+      activityData?.status === ActivityStatus.CANCELED
+    ) {
+      showError("無法編輯已結束或已取消的活動");
+      return;
+    }
+
     const numericEventId = Number.parseInt(eventId);
     if (Number.isNaN(numericEventId)) {
       showError("無效的活動 ID");
@@ -196,7 +205,12 @@ export default function CategoryPage() {
         <div className="flex justify-center mt-6 border-t border-gray-200 pt-6 w-full">
           <Button
             onClick={handleSubmit}
-            disabled={selectedCategories.length === 0 || isUpdating}
+            disabled={
+              selectedCategories.length === 0 ||
+              isUpdating ||
+              activityData?.status === ActivityStatus.ENDED ||
+              activityData?.status === ActivityStatus.CANCELED
+            }
             className="bg-[#FFD56B] text-[#262626] rounded-lg w-full py-2 text-base font-normal hover:bg-[#FFCA28] transition-colors cursor-pointer h-auto disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isUpdating ? "更新中..." : "儲存"}

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/eventplacetype/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/eventplacetype/page.tsx
@@ -18,6 +18,7 @@ import { Camera, ExternalLink, UserCheck } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { ActivityStatus } from "../../../page";
 
 export default function EventPlaceTypePage() {
   const router = useRouter();
@@ -91,6 +92,14 @@ export default function EventPlaceTypePage() {
 
   // 處理表單提交
   const handleSubmit = async () => {
+    if (
+      activityData?.status === ActivityStatus.ENDED ||
+      activityData?.status === ActivityStatus.CANCELED
+    ) {
+      showError("無法編輯已結束或已取消的活動");
+      return;
+    }
+
     const numericEventId = Number.parseInt(eventId);
     if (Number.isNaN(numericEventId)) {
       showError("無效的活動 ID");
@@ -242,7 +251,12 @@ export default function EventPlaceTypePage() {
         <div className="flex justify-center mt-8 border-t border-gray-200 pt-8">
           <Button
             onClick={handleSubmit}
-            disabled={!canProceed || isUpdating}
+            disabled={
+              !canProceed ||
+              isUpdating ||
+              activityData?.status === ActivityStatus.ENDED ||
+              activityData?.status === ActivityStatus.CANCELED
+            }
             className={`${
               canProceed && !isUpdating
                 ? "bg-[#FFD56B] hover:bg-[#FFCA28] cursor-pointer"

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/intro/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/intro/page.tsx
@@ -15,6 +15,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { ActivityStatus } from "../../../page";
 
 // 動態導入 QuillEditor，確保只在客戶端渲染
 const QuillEditor = dynamic(() => import("@/components/ui/quill-editor"), {
@@ -113,6 +114,14 @@ export default function IntroPage() {
   // 處理表單提交
   const onSubmit = useCallback(
     async (data: IntroFormData) => {
+      if (
+        activityData?.status === ActivityStatus.ENDED ||
+        activityData?.status === ActivityStatus.CANCELED
+      ) {
+        showError("無法編輯已結束或已取消的活動");
+        return;
+      }
+
       const numericEventId = Number.parseInt(eventId);
       if (Number.isNaN(numericEventId)) {
         showError("無效的活動 ID");
@@ -245,7 +254,12 @@ export default function IntroPage() {
         <div className="flex justify-center pt-4">
           <Button
             type="submit"
-            disabled={!isValid || isUpdating}
+            disabled={
+              !isValid ||
+              isUpdating ||
+              activityData?.status === ActivityStatus.ENDED ||
+              activityData?.status === ActivityStatus.CANCELED
+            }
             className={`${
               isValid && !isUpdating
                 ? "bg-[#FFD56B] hover:bg-[#FFCA28] cursor-pointer"

--- a/src/app/(organizer)/organizer/events/[eventId]/edit/tickets/setting/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/edit/tickets/setting/page.tsx
@@ -40,6 +40,7 @@ import {
   useWatch,
 } from "react-hook-form";
 import { toast } from "sonner";
+import { ActivityStatus } from "../../../../page";
 
 // 票券操作選單組件
 const TicketActionsMenu = memo(
@@ -756,6 +757,14 @@ export default function TicketSettingPage() {
 
   const onSubmit = useCallback(
     async (data: TicketSettingFormData) => {
+      if (
+        activityData?.status === ActivityStatus.ENDED ||
+        activityData?.status === ActivityStatus.CANCELED
+      ) {
+        showError("無法編輯已結束或已取消的活動");
+        return;
+      }
+
       const numericEventId = Number.parseInt(eventId);
       if (Number.isNaN(numericEventId) || !activityData) {
         showError("缺少必要資料，請確認活動信息是否完整");
@@ -1090,7 +1099,12 @@ export default function TicketSettingPage() {
         <div className="flex justify-center border-t border-gray-200 pt-6">
           <Button
             type="submit"
-            disabled={!isValid || isSubmitting}
+            disabled={
+              !isValid ||
+              isSubmitting ||
+              activityData?.status === ActivityStatus.ENDED ||
+              activityData?.status === ActivityStatus.CANCELED
+            }
             className={`${
               isValid && !isSubmitting
                 ? "bg-[#FFD56B] hover:bg-[#FFCA28] cursor-pointer"

--- a/src/app/(organizer)/organizer/events/[eventId]/page.tsx
+++ b/src/app/(organizer)/organizer/events/[eventId]/page.tsx
@@ -27,6 +27,7 @@ import { BarChart3, Calendar, Edit3, Eye, TrendingUp, Upload } from "lucide-reac
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ActivityStatus } from "../page";
 
 interface EventStats {
   views: number;
@@ -186,6 +187,13 @@ export default function EventDetailPage() {
   // 處理封面圖片上傳
   const handleCoverUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (
+        activityData?.status === ActivityStatus.ENDED ||
+        activityData?.status === ActivityStatus.CANCELED
+      ) {
+        return;
+      }
+
       const file = e.target.files?.[0];
       if (!file) return;
 
@@ -235,8 +243,18 @@ export default function EventDetailPage() {
       }
     },
     [eventId, handleError, loadActivityData]
-  ); // 觸發檔案選擇
+  );
+
+  // 觸發檔案選擇
   const handleCoverClick = () => {
+    if (
+      activityData?.status === ActivityStatus.ENDED ||
+      activityData?.status === ActivityStatus.CANCELED
+    ) {
+      toast.error("無法編輯已結束或已取消的活動");
+      return;
+    }
+
     fileInputRef.current?.click();
   };
 

--- a/src/app/(organizer)/organizer/events/page.tsx
+++ b/src/app/(organizer)/organizer/events/page.tsx
@@ -26,7 +26,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 // 活動狀態枚舉
-enum ActivityStatus {
+export enum ActivityStatus {
   DRAFT = "draft",
   PUBLISHED = "published",
   ENDED = "ended",

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -41,15 +41,15 @@ const exploreLinks: FooterLink[] = [
   //   href: "/events?categoryId=ai-recommended",
   //   label: "AI 為您推薦",
   // },
-  { id: "faq", href: "/faq", label: "常見問題" },
+  { id: "faq", href: "#", label: "常見問題" },
 ];
 
 // 舉辦活動連結
 const hostLinks: FooterLink[] = [
-  { id: "register", href: "/host/register", label: "成為活動主辦人" },
-  { id: "online", href: "/host/guidelines/online", label: "線上活動規範" },
-  { id: "offline", href: "/host/guidelines/offline", label: "線下活動規範" },
-  { id: "hostfaq", href: "/host/faq", label: "常見問題" },
+  { id: "register", href: "#", label: "成為活動主辦人" },
+  { id: "online", href: "#", label: "線上活動規範" },
+  { id: "offline", href: "#", label: "線下活動規範" },
+  { id: "hostfaq", href: "#", label: "常見問題" },
 ];
 
 // 社交媒體圖示元件

--- a/src/store/create-event.ts
+++ b/src/store/create-event.ts
@@ -115,7 +115,7 @@ export const useCreateEventStore = create<CreateEventState>()(
 
             return eventId;
           }
-          throw new Error("建立活動失敗：無法獲取活動 ID");
+          throw new Error(response.error?.message || "建立活動失敗，請稍後再試");
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : "建立活動失敗";
           set({ error: errorMessage, isLoading: false });


### PR DESCRIPTION
## Story/Why
Linked Trello: (對應 Trello 卡片之連結)
X

## Solution
* [footer 的連結目前沒有頁面](https://www.notion.so/footer-2146a24685188088931eeb66c31a1096?source=copy_link)
* [活動建立 線上活動直播連結亂填錯誤訊息不完整](https://www.notion.so/2166a246851880f485f7f0b72795cff9?source=copy_link)
* 額外-活動編輯卡控 已結束、已結束 不可編輯更新

## Additional Note
X
