### PR TITLE
[修正/優化]活動詳情/註冊登入

### DIFF
--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -525,10 +525,58 @@ export default function EventDetailPage() {
             </div>
             <div className="flex flex-col gap-2 mt-0 lg:mt-16">
               <div
-                className="text-base text-[#525252]"
+                className="text-base text-[#525252] markdown-content"
                 // biome-ignore lint/security/noDangerouslySetInnerHtml: 已用 DOMPurify 處理
                 dangerouslySetInnerHTML={{
-                  __html: DOMPurify.sanitize(eventData?.descriptionMd ?? ""),
+                  __html: (() => {
+                    const rawHtml = eventData?.descriptionMd ?? "";
+                    if (!rawHtml) return "";
+
+                    // 創建臨時 DOM 元素來處理連結
+                    const tempDiv = document.createElement("div");
+                    tempDiv.innerHTML = rawHtml;
+
+                    // 為所有連結添加 target="_blank" 和 rel="noopener noreferrer"
+                    const links = tempDiv.querySelectorAll("a");
+                    for (const link of links) {
+                      link.setAttribute("target", "_blank");
+                      link.setAttribute("rel", "noopener noreferrer");
+                    }
+
+                    // 使用 DOMPurify 清理 HTML，並允許 target 和 rel 屬性
+                    return DOMPurify.sanitize(tempDiv.innerHTML, {
+                      ALLOWED_ATTR: ["href", "target", "rel", "class", "id", "style"],
+                      ALLOWED_TAGS: [
+                        "a",
+                        "p",
+                        "br",
+                        "strong",
+                        "em",
+                        "u",
+                        "h1",
+                        "h2",
+                        "h3",
+                        "h4",
+                        "h5",
+                        "h6",
+                        "ul",
+                        "ol",
+                        "li",
+                        "blockquote",
+                        "code",
+                        "pre",
+                        "table",
+                        "thead",
+                        "tbody",
+                        "tr",
+                        "th",
+                        "td",
+                        "img",
+                        "div",
+                        "span",
+                      ],
+                    });
+                  })(),
                 }}
               />
             </div>

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -6,14 +6,9 @@ import TicketGuideDialog from "@/features/activities/components/ticket-guide-dia
 import {
   deleteApiV1ActivitiesByActivityIdFavorite,
   getApiV1ActivitiesByActivityId,
-  getApiV1OrganizationsByOrganizationId,
   postApiV1ActivitiesByActivityIdFavorite,
 } from "@/services/api/client/sdk.gen";
-import type {
-  ActivityResponse,
-  FavoriteActivityResponse,
-  OrganizationResponse,
-} from "@/services/api/client/types.gen";
+import type { ActivityResponse } from "@/services/api/client/types.gen";
 import { useAuthStore } from "@/store/auth";
 import { useDialogStore } from "@/store/dialog";
 import { useSearchStore } from "@/store/search";
@@ -48,7 +43,6 @@ export default function EventDetailPage() {
   const setLoginTab = useDialogStore((s) => s.setLoginTab);
   const router = useRouter();
   const [eventData, setEventData] = useState<ActivityResponse | null>(null);
-  const [organization, setOrganization] = useState<OrganizationResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const setSearchValue = useSearchStore((s) => s.setSearchValue);
@@ -67,14 +61,6 @@ export default function EventDetailPage() {
         setEventData(res.data?.data ?? null);
         setLiked(res.data?.data?.userStatus?.isFavorite ?? false);
         if (!res.data?.data) setError("查無此活動");
-        const orgId = res.data?.data?.organizationId;
-        if (orgId) {
-          getApiV1OrganizationsByOrganizationId({
-            path: { organizationId: Number(orgId) },
-          }).then((orgRes) => {
-            setOrganization(orgRes.data?.data ?? null);
-          });
-        }
       })
       .catch(() => setError("載入活動資料失敗"))
       .finally(() => setLoading(false));
@@ -82,6 +68,9 @@ export default function EventDetailPage() {
 
   // 活動地點變數
   const eventLocation = eventData?.location || "";
+
+  // 從活動資料中取得主辦單位資訊
+  const organization = eventData?.organization;
 
   const handleCheckout = () => {
     if (isAuthenticated) {

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -249,7 +249,7 @@ export default function EventDetailPage() {
             </div>
             <div className="flex-1 flex flex-col gap-10">
               {/* 關於活動 */}
-              <p className="text-neutral-800 leading-relaxed mt-0 lg:mt-16">
+              <p className="text-neutral-800 leading-relaxed mt-0 lg:mt-16 whitespace-pre-line">
                 {eventData?.summary ?? ""}
               </p>
               <div className="flex flex-wrap gap-2">

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -298,11 +298,25 @@ export default function EventDetailPage() {
               </div>
               <Separator />
               <div className="flex flex-col lg:flex-row items-start gap-3 pl-0 lg:pl-8">
-                <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
-                  <MapPin className="w-5 h-5" />
-                  活動地點
-                </span>
-                <span className="text-neutral-800">{eventLocation}</span>
+                {eventData?.isOnline && !eventLocation ? (
+                  <>
+                    <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
+                      <VideoIcon className="w-5 h-5" />
+                      線上活動
+                    </span>
+                    <span className="text-neutral-800">
+                      此活動為線上活動，購票後可於票券頁進入直播連結
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
+                      <MapPin className="w-5 h-5" />
+                      活動地點
+                    </span>
+                    <span className="text-neutral-800">{eventLocation}</span>
+                  </>
+                )}
               </div>
               <Separator />
               <div className="flex flex-col lg:flex-row items-start gap-3 pl-0 lg:pl-8">
@@ -404,7 +418,7 @@ export default function EventDetailPage() {
                   </span>
                   <span className="text-neutral-500 text-sm">
                     {eventData?.isOnline
-                      ? "本課程使用Zoom進行，報名後會於課前收到課程的Zoom連結，請留意您的Email信箱"
+                      ? "購票後可於票券頁進入直播連結"
                       : "實際入場相關規定以活動主辦方為主"}
                   </span>
                 </div>

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -288,28 +288,19 @@ export default function EventDetailPage() {
                 </a>
               </div>
               <Separator />
-              <div className="flex flex-col lg:flex-row items-start gap-3 pl-0 lg:pl-8">
-                {eventData?.isOnline && !eventLocation ? (
-                  <>
-                    <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
-                      <VideoIcon className="w-5 h-5" />
-                      線上活動
-                    </span>
-                    <span className="text-neutral-800">
-                      此活動為線上活動，購票後可於票券頁進入直播連結
-                    </span>
-                  </>
-                ) : (
-                  <>
+              {/* 只有線下活動才顯示活動地點 */}
+              {!eventData?.isOnline && (
+                <>
+                  <div className="flex flex-col lg:flex-row items-start gap-3 pl-0 lg:pl-8">
                     <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
                       <MapPin className="w-5 h-5" />
                       活動地點
                     </span>
                     <span className="text-neutral-800">{eventLocation}</span>
-                  </>
-                )}
-              </div>
-              <Separator />
+                  </div>
+                  <Separator />
+                </>
+              )}
               <div className="flex flex-col lg:flex-row items-start gap-3 pl-0 lg:pl-8">
                 <span className="inline-flex items-center gap-2 text-neutral-800 font-bold text-lg lg:text-base">
                   <LinkIcon className="w-5 h-5" />

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -113,6 +113,7 @@ export default function EventDetailPage() {
         });
         setLiked(false);
         toast.success("已取消收藏");
+        setEventData((prev) => (prev ? { ...prev, likeCount: (prev.likeCount || 0) - 1 } : prev));
       } else {
         // 新增收藏
         await postApiV1ActivitiesByActivityIdFavorite({
@@ -120,6 +121,7 @@ export default function EventDetailPage() {
         });
         setLiked(true);
         toast.success("已加入收藏");
+        setEventData((prev) => (prev ? { ...prev, likeCount: (prev.likeCount || 0) + 1 } : prev));
       }
     } catch (error) {
       toast.error(liked ? "取消收藏失敗" : "收藏失敗");

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -653,9 +653,9 @@ export default function EventDetailPage() {
             <div className="flex flex-col items-center gap-2">
               <div className="flex items-center gap-2">
                 <EyeIcon className="w-5 h-5 text-neutral-500" />
-                <span className="text-neutral-500 font-bold">{eventData?.viewCount ?? 0} 人</span>
+                <span className="text-neutral-500 font-bold">{eventData?.viewCount ?? 0} 次</span>
               </div>
-              <span className="text-neutral-500">正在關注活動</span>
+              <span className="text-neutral-500">瀏覽</span>
             </div>
             {/* 垂直分隔線 */}
             <div className="w-0.5 h-14 bg-neutral-400" />

--- a/src/features/auth/schemas.ts
+++ b/src/features/auth/schemas.ts
@@ -17,6 +17,7 @@ export const signUpSchema = z
     password: z
       .string()
       .min(8, "密碼長度至少需要 8 個字符")
+      .max(16, "密碼長度不能超過 16 個字符")
       .regex(/^[a-zA-Z0-9]+$/, "密碼只能包含英文或數字"),
     checkPassword: z.string(),
   })
@@ -40,6 +41,7 @@ export const resetPasswordSchema = z
     password: z
       .string()
       .min(8, "密碼長度至少需要 8 個字符")
+      .max(16, "密碼長度不能超過 16 個字符")
       .regex(/^[a-zA-Z0-9]+$/, "密碼只能包含英文或數字"),
     confirmPassword: z.string().min(1, "請確認密碼"),
     resetToken: z.string().min(1, "請輸入重設密碼驗證碼"),

--- a/src/services/api/client/sdk.gen.ts
+++ b/src/services/api/client/sdk.gen.ts
@@ -103,6 +103,9 @@ import type {
   PostApiV1ActivitiesData,
   PostApiV1ActivitiesError,
   PostApiV1ActivitiesResponse,
+  PostApiV1CategoriesByCategoryIdImageData,
+  PostApiV1CategoriesByCategoryIdImageError,
+  PostApiV1CategoriesByCategoryIdImageResponse,
   PostApiV1ChatData,
   PostApiV1ChatError,
   PostApiV1ChatResponse,
@@ -715,6 +718,34 @@ export const getApiV1Categories = <ThrowOnError extends boolean = false>(
     ],
     url: "/api/v1/categories",
     ...options,
+  });
+};
+
+/**
+ * 編輯主題圖片
+ * 照片大小限制4MB內
+ */
+export const postApiV1CategoriesByCategoryIdImage = <ThrowOnError extends boolean = false>(
+  options: Options<PostApiV1CategoriesByCategoryIdImageData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).post<
+    PostApiV1CategoriesByCategoryIdImageResponse,
+    PostApiV1CategoriesByCategoryIdImageError,
+    ThrowOnError
+  >({
+    ...formDataBodySerializer,
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/v1/categories/{categoryId}/image",
+    ...options,
+    headers: {
+      "Content-Type": null,
+      ...options?.headers,
+    },
   });
 };
 

--- a/src/services/api/client/types.gen.ts
+++ b/src/services/api/client/types.gen.ts
@@ -42,6 +42,13 @@ export type ActivityResponse = {
     isFavorite?: boolean;
     isRegistered?: boolean;
   };
+  organization?: {
+    id?: number;
+    name?: string;
+    avatar?: string;
+    email?: string;
+    officialSiteUrl?: string;
+  };
 };
 
 export type CreateActivityRequest = {
@@ -958,14 +965,6 @@ export type TicketTypeResponse = {
    */
   endTime?: string;
   /**
-   * 開賣時間，格式為 ISO 8601
-   */
-  saleStartAt?: string | null;
-  /**
-   * 開賣結束時間，格式為 ISO 8601
-   */
-  saleEndAt?: string | null;
-  /**
    * 是否為活動中
    */
   isActive?: boolean;
@@ -1492,7 +1491,7 @@ export type PutApiV1ActivitiesByActivityIdTicketTypesByTicketTypeIdData = {
 
 export type PutApiV1ActivitiesByActivityIdTicketTypesByTicketTypeIdErrors = {
   /**
-   * 格式錯誤、票種名稱已存在，請使用其他名稱、票種的銷售開始時間不可晚於活動結束時間、票種的銷售結束時間不可晚於活動結束時間
+   * 格式錯誤、票種名稱已存在，請使用其他名稱、票種的銷售開始時間不可晚於活動結束時間、票種的銷售結束時間不可晚於活動結束時間、該票種已經有票券被使用或分配，無法編輯、該票種已經有票券被使用或分配，無法刪除
    */
   400: ErrorResponse;
   /**
@@ -2192,6 +2191,51 @@ export type GetApiV1CategoriesResponses = {
 export type GetApiV1CategoriesResponse =
   GetApiV1CategoriesResponses[keyof GetApiV1CategoriesResponses];
 
+export type PostApiV1CategoriesByCategoryIdImageData = {
+  body: {
+    /**
+     * 使用者上傳的圖片檔案，僅接受 image*
+     */
+    image?: Blob | File;
+  };
+  path: {
+    /**
+     * 主題 ID
+     */
+    categoryId: number;
+  };
+  query?: never;
+  url: "/api/v1/categories/{categoryId}/image";
+};
+
+export type PostApiV1CategoriesByCategoryIdImageErrors = {
+  /**
+   * 錯誤的請求，例如沒有圖片、圖片上傳失敗等
+   */
+  400: ErrorResponse;
+  /**
+   * 非管理者權限，無法編輯主題圖片
+   */
+  403: ErrorResponse;
+  /**
+   * 主題不存在
+   */
+  404: ErrorResponse;
+};
+
+export type PostApiV1CategoriesByCategoryIdImageError =
+  PostApiV1CategoriesByCategoryIdImageErrors[keyof PostApiV1CategoriesByCategoryIdImageErrors];
+
+export type PostApiV1CategoriesByCategoryIdImageResponses = {
+  /**
+   * 上傳成功
+   */
+  200: UploadCoverResponse;
+};
+
+export type PostApiV1CategoriesByCategoryIdImageResponse =
+  PostApiV1CategoriesByCategoryIdImageResponses[keyof PostApiV1CategoriesByCategoryIdImageResponses];
+
 export type PostApiV1ChatData = {
   body: ChatRequest;
   path?: never;
@@ -2856,7 +2900,7 @@ export type PatchApiV1TicketsByTicketIdUsedData = {
 
 export type PatchApiV1TicketsByTicketIdUsedErrors = {
   /**
-   * 格式錯誤
+   * 格式錯誤、活動尚未開始，無法報到、活動已結束，無法報到
    */
   400: ErrorResponse;
   /**

--- a/src/styles/customs/markdown.css
+++ b/src/styles/customs/markdown.css
@@ -30,8 +30,37 @@
   font-style: italic;
 }
 
+/* 連結樣式 */
 .markdown-content a {
   word-break: break-all;
+  color: #f07348; /* 使用 secondary 色系 */
+  text-decoration: underline;
+  text-decoration-color: #f07348;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+  transition: all 0.2s ease-in-out;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.markdown-content a:hover {
+  color: #c35d3a; /* secondary-600 */
+  text-decoration-color: #c35d3a;
+  background-color: rgba(240, 115, 72, 0.1); /* secondary 色系半透明背景 */
+  border-radius: 4px;
+}
+
+.markdown-content a:focus {
+  outline: 2px solid #f07348;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* 外部連結樣式（可選） */
+.markdown-content a[href^="http"]::after {
+  content: " ↗";
+  font-size: 0.8em;
+  opacity: 0.7;
 }
 
 /* 確保在小尺寸容器中的可讀性 */
@@ -63,5 +92,11 @@
 
   .markdown-content table {
     font-size: 0.75rem;
+  }
+
+  /* 手機版連結樣式調整 */
+  .markdown-content a {
+    text-decoration-thickness: 1px;
+    text-underline-offset: 1px;
   }
 }


### PR DESCRIPTION
## Story/Why
Linked Trello: [https://trello.com/c/6EMloUwA](https://trello.com/c/6EMloUwA)
調整/優化測試項目

## Solution
- 串接收藏/取消收藏 API（[連結](https://www.notion.so/2156a2468518801aba8cd52141c0da98?source=copy_link)）
- [活動詳情]線上活動改顯示線上活動文字（[連結](https://www.notion.so/2166a24685188059aaaed4e5bd21133c?source=copy_link)）
- 補上密碼最長字元限制與後端密碼規則對齊（[連結](https://www.notion.so/2156a246851880d2834cf93cfc441142?source=copy_link)）
- [活動詳情]活動摘要根據填寫內容呈現換行（[連結](https://www.notion.so/2166a246851880cbab98fd1c48c17225?source=copy_link)）
- [活動詳情]新增活動簡介連結樣式（[連結](https://www.notion.so/2176a2468518802db1d2e61bedd5552d?source=copy_link)）
- [活動詳情] 瀏覽次數文字調整 （[連結](https://www.notion.so/ViewCount-n-2176a2468518805ca145d86171734e15?source=copy_link)）
- 補充調整從單一活動 API 取主辦資訊

## Additional Note
收藏目前僅串接 API，後續有餘裕可新增收藏活動頁面
